### PR TITLE
Update response for get timeline and crop validations (WIP)

### DIFF
--- a/src/videoserver/apps/projects/routes.py
+++ b/src/videoserver/apps/projects/routes.py
@@ -1126,18 +1126,18 @@ class RetrieveOrCreateThumbnails(MethodView):
                 "processing": False,
                 "thumbnails": self.project['thumbnails']['timeline'],
             })
-        if self.project['processing']['thumbnails_timeline'] is False:            
-          # set processing flag
-          self.project = app.mongo.db.projects.find_one_and_update(
-              {'_id': self.project['_id']},
-              {'$set': {'processing.thumbnails_timeline': True}},
-              return_document=ReturnDocument.AFTER
-          )
-          # run task
-          generate_timeline_thumbnails.delay(
-              self.project,
-              amount
-          )
+        if self.project['processing']['thumbnails_timeline'] is False:
+            # set processing flag
+            self.project = app.mongo.db.projects.find_one_and_update(
+                {'_id': self.project['_id']},
+                {'$set': {'processing.thumbnails_timeline': True}},
+                return_document=ReturnDocument.AFTER
+            )
+            # run task
+            generate_timeline_thumbnails.delay(
+                self.project,
+                amount
+            )
         return json_response({
             "processing": True,
             "thumbnails": [],

--- a/src/videoserver/apps/projects/routes.py
+++ b/src/videoserver/apps/projects/routes.py
@@ -972,6 +972,9 @@ class RetrieveOrCreateThumbnails(MethodView):
                 processing:
                   type: boolean
                   example: True
+                thumbnails:
+                  type: array
+                  example: []
           409:
             description: Timeline/preview task is still processing
             schema:
@@ -1119,7 +1122,10 @@ class RetrieveOrCreateThumbnails(MethodView):
             raise Conflict({"processing": ["Task get timeline thumbnails video is still processing"]})
         # no need to generate thumbnails
         elif amount == len(self.project['thumbnails']['timeline']):
-            return json_response({"thumbnails": self.project['thumbnails']['timeline']})
+            return json_response({
+                "processing": False,
+                "thumbnails": self.project['thumbnails']['timeline'],
+            })
         else:
             # set processing flag
             self.project = app.mongo.db.projects.find_one_and_update(
@@ -1132,7 +1138,10 @@ class RetrieveOrCreateThumbnails(MethodView):
                 self.project,
                 amount
             )
-            return json_response({"processing": True}, status=202)
+            return json_response({
+                "processing": True,
+                "thumbnails": [],
+            }, status=202)
 
     def _get_preview_thumbnail(self, position, crop, rotate):
         """

--- a/src/videoserver/apps/projects/routes.py
+++ b/src/videoserver/apps/projects/routes.py
@@ -1119,7 +1119,7 @@ class RetrieveOrCreateThumbnails(MethodView):
             raise Conflict({"processing": ["Task get timeline thumbnails video is still processing"]})
         # no need to generate thumbnails
         elif amount == len(self.project['thumbnails']['timeline']):
-            return json_response(self.project['thumbnails']['timeline'])
+            return json_response({"thumbnails": self.project['thumbnails']['timeline']})
         else:
             # set processing flag
             self.project = app.mongo.db.projects.find_one_and_update(

--- a/src/videoserver/lib/utils.py
+++ b/src/videoserver/lib/utils.py
@@ -169,9 +169,9 @@ class VideoValidator(Validator):
         if limit and len(limit) == 2:
             wmin, wmax = limit
             if value['width'] < wmin:
-                self._error(field, "width is lesser than minimum allowed crop width")
+                self._error(field, f"width {value['width']} is less than minimum allowed crop width ({wmin})")
             if value['width'] > wmax:
-                self._error(field, "width is greater than maximum allowed crop width")
+                self._error(field, f"width {value['width']} is greater than maximum allowed crop width ({wmax})")
 
     def _validate_allow_crop_height(self, limit, field, value):
         """Test allowed crop height range
@@ -181,9 +181,9 @@ class VideoValidator(Validator):
         if limit and len(limit) == 2:
             hmin, hmax = limit
             if value['height'] < hmin:
-                self._error(field, "height is lesser than minimum allowed crop height")
+                self._error(field, f"height {value['height']} is less than minimum allowed crop height ({hmin})")
             if value['height'] > hmax:
-                self._error(field, "height is greater than maximum allowed crop height")
+                self._error(field, f"height {value['height']} is greater than maximum allowed crop height ({hmax})")
 
     def _validate_min_trim_start(self, min_trim, field, value):
         """Test minimum allowed trim start value

--- a/tests/api/test_retrieve_create_thumbnails.py
+++ b/tests/api/test_retrieve_create_thumbnails.py
@@ -80,7 +80,8 @@ def test_capture_timeline_thumbnails_409_resp(test_app, client, projects):
         )
 
         resp = client.get(url)
-        assert resp.status == '409 CONFLICT'
+        assert resp.status == '200 OK'
+        assert resp_data == {'processing': True, 'thumbnails': []}
 
 
 @pytest.mark.parametrize('projects', [({'file': 'sample_0.mp4', 'duplicate': False},)], indirect=True)

--- a/tests/api/test_retrieve_create_thumbnails.py
+++ b/tests/api/test_retrieve_create_thumbnails.py
@@ -18,13 +18,13 @@ def test_capture_timeline_thumbnails_success(test_app, client, projects):
         resp = client.get(url)
         resp_data = json.loads(resp.data)
         assert resp.status == '202 ACCEPTED'
-        assert resp_data == {'processing': True}
+        assert resp_data == {'processing': True, 'thumbnails': []}
 
         resp = client.get(url)
         resp_data = json.loads(resp.data)
         assert resp.status == '200 OK'
-        assert len(resp_data) == amount
-        for thumbnail_data in resp_data:
+        assert len(resp_data['thumbnails']) == amount
+        for thumbnail_data in resp_data['thumbnails']:
             assert test_app.fs.get(thumbnail_data['storage_id']).__class__ is bytes
 
 
@@ -47,13 +47,13 @@ def test_capture_timeline_thumbnails_remove_old(test_app, client, projects):
         resp = client.get(url)
         resp_data = json.loads(resp.data)
         assert resp.status == '202 ACCEPTED'
-        assert resp_data == {'processing': True}
+        assert resp_data == {'processing': True, 'thumbnails': []}
 
         resp = client.get(url)
         resp_data = json.loads(resp.data)
         assert resp.status == '200 OK'
-        assert len(resp_data) == amount
-        for thumbnail_data in resp_data:
+        assert len(resp_data['thumbnails']) == amount
+        for thumbnail_data in resp_data['thumbnails']:
             assert test_app.fs.get(thumbnail_data['storage_id']).__class__ is bytes
 
 
@@ -69,7 +69,7 @@ def test_capture_timeline_thumbnails_409_resp(test_app, client, projects):
         resp = client.get(url)
         resp_data = json.loads(resp.data)
         assert resp.status == '202 ACCEPTED'
-        assert resp_data == {'processing': True}
+        assert resp_data == {'processing': True, 'thumbnails': []}
 
         # since we use CELERY_TASK_ALWAYS_EAGER, task will be executed immediately,
         # it means next request will return a finshed result,

--- a/tests/api/test_retrieve_create_thumbnails.py
+++ b/tests/api/test_retrieve_create_thumbnails.py
@@ -176,7 +176,7 @@ def test_capture_preview_thumbnail_crop_fail(test_app, client, projects):
         resp = client.get(url)
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'crop': ['width is greater than maximum allowed crop width']}
+        assert resp_data == {'crop': ['width 10000 is greater than maximum allowed crop width (3840)']}
 
         crop = "0,0,640,10000"
         url = url_for(
@@ -185,7 +185,7 @@ def test_capture_preview_thumbnail_crop_fail(test_app, client, projects):
         resp = client.get(url)
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'crop': ['height is greater than maximum allowed crop height']}
+        assert resp_data == {'crop': ['height 10000 is greater than maximum allowed crop height (2160)']}
 
         crop = "0,0,1640,480"
         url = url_for(

--- a/tests/api/test_retrieve_edit_destroy.py
+++ b/tests/api/test_retrieve_edit_destroy.py
@@ -380,7 +380,7 @@ def test_edit_project_crop_fail(test_app, client, projects):
         )
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'crop': ['width is greater than maximum allowed crop width']}
+        assert resp_data == {'crop': ['width 10000 is greater than maximum allowed crop width (3840)']}
 
         # edit request
         resp = client.put(
@@ -392,7 +392,7 @@ def test_edit_project_crop_fail(test_app, client, projects):
         )
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'crop': ['width is lesser than minimum allowed crop width']}
+        assert resp_data == {'crop': ['width 300 is less than minimum allowed crop width (320)']}
 
         # edit request
         resp = client.put(
@@ -404,7 +404,7 @@ def test_edit_project_crop_fail(test_app, client, projects):
         )
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'crop': ['height is lesser than minimum allowed crop height']}
+        assert resp_data == {'crop': ['height 100 is less than minimum allowed crop height (180)']}
 
 
 @pytest.mark.parametrize('projects', [({'file': 'sample_0.mp4', 'duplicate': True},)], indirect=True)


### PR DESCRIPTION
Changes:
- Update `GET` timeline response returns _**thumbnails object** contains **list of timeline**_ instead of returning JSON array (list timeline)
- Add _current value and limit_ for crop validation error response. 
While working on the client, we notice that crop validation responses are not helpful, because user don't know what is the current limit without retrying until it worked