### PR TITLE
Update API error response

### DIFF
--- a/src/videoserver/apps/projects/routes.py
+++ b/src/videoserver/apps/projects/routes.py
@@ -1126,18 +1126,18 @@ class RetrieveOrCreateThumbnails(MethodView):
                 "processing": False,
                 "thumbnails": self.project['thumbnails']['timeline'],
             })
-        if self.project['processing']['thumbnails_timeline'] is False:            
-          # set processing flag
-          self.project = app.mongo.db.projects.find_one_and_update(
-              {'_id': self.project['_id']},
-              {'$set': {'processing.thumbnails_timeline': True}},
-              return_document=ReturnDocument.AFTER
-          )
-          # run task
-          generate_timeline_thumbnails.delay(
-              self.project,
-              amount
-          )
+        if self.project['processing']['thumbnails_timeline'] is False:
+            # set processing flag
+            self.project = app.mongo.db.projects.find_one_and_update(
+                {'_id': self.project['_id']},
+                {'$set': {'processing.thumbnails_timeline': True}},
+                return_document=ReturnDocument.AFTER
+            )
+            # run task
+            generate_timeline_thumbnails.delay(
+                self.project,
+                amount
+            )
         return json_response({
             "processing": True,
             "thumbnails": [],

--- a/src/videoserver/apps/projects/routes.py
+++ b/src/videoserver/apps/projects/routes.py
@@ -15,7 +15,7 @@ from videoserver.lib.video_editor import get_video_editor
 from videoserver.lib.views import MethodView
 from videoserver.lib.utils import (
     add_urls, create_file_name, get_request_address, json_response, paginate, save_activity_log, storage2response,
-    validate_document, coerce_crop_str_to_dict, coerce_trim_str_to_dict
+    validate_document
 )
 
 from . import bp
@@ -339,7 +339,7 @@ class RetrieveEditDestroyProject(MethodView):
             'trim': {
                 'required': False,
                 'regex': r'^\d+\.?\d*,\d+\.?\d*$',
-                'coerce': coerce_trim_str_to_dict,
+                'coerce': 'trim_to_dict',
                 'min_trim_start': 0,
                 'min_trim_end': 1
             },
@@ -357,7 +357,7 @@ class RetrieveEditDestroyProject(MethodView):
             'crop': {
                 'required': False,
                 'regex': r'^\d+,\d+,\d+,\d+$',
-                'coerce': coerce_crop_str_to_dict,
+                'coerce': 'crop_to_dict',
                 'allow_crop_width': [app.config.get('MIN_VIDEO_WIDTH'), app.config.get('MAX_VIDEO_WIDTH')],
                 'allow_crop_height': [app.config.get('MIN_VIDEO_HEIGHT'), app.config.get('MAX_VIDEO_HEIGHT')]
             }
@@ -881,7 +881,7 @@ class RetrieveOrCreateThumbnails(MethodView):
             'crop': {
                 'required': False,
                 'regex': r'^\d+,\d+,\d+,\d+$',
-                'coerce': coerce_crop_str_to_dict,
+                'coerce': 'crop_to_dict',
                 'allow_crop_width': [app.config.get('MIN_VIDEO_WIDTH'), app.config.get('MAX_VIDEO_WIDTH')],
                 'allow_crop_height': [app.config.get('MIN_VIDEO_HEIGHT'), app.config.get('MAX_VIDEO_HEIGHT')]
             },

--- a/src/videoserver/apps/projects/routes.py
+++ b/src/videoserver/apps/projects/routes.py
@@ -972,6 +972,9 @@ class RetrieveOrCreateThumbnails(MethodView):
                 processing:
                   type: boolean
                   example: True
+                thumbnails:
+                  type: array
+                  example: []
           409:
             description: Timeline/preview task is still processing
             schema:
@@ -1119,7 +1122,10 @@ class RetrieveOrCreateThumbnails(MethodView):
             raise Conflict({"processing": ["Task get timeline thumbnails video is still processing"]})
         # no need to generate thumbnails
         elif amount == len(self.project['thumbnails']['timeline']):
-            return json_response({"thumbnails": self.project['thumbnails']['timeline']})
+            return json_response({
+                "processing": False,
+                "thumbnails": self.project['thumbnails']['timeline'],
+            })
         else:
             # set processing flag
             self.project = app.mongo.db.projects.find_one_and_update(
@@ -1132,7 +1138,10 @@ class RetrieveOrCreateThumbnails(MethodView):
                 self.project,
                 amount
             )
-            return json_response({"processing": True}, status=202)
+            return json_response({
+                "processing": True,
+                "thumbnails": [],
+            }, status=202)
 
     def _get_preview_thumbnail(self, position, crop, rotate):
         """

--- a/src/videoserver/apps/projects/routes.py
+++ b/src/videoserver/apps/projects/routes.py
@@ -1119,7 +1119,7 @@ class RetrieveOrCreateThumbnails(MethodView):
             raise Conflict({"processing": ["Task get timeline thumbnails video is still processing"]})
         # no need to generate thumbnails
         elif amount == len(self.project['thumbnails']['timeline']):
-            return json_response(self.project['thumbnails']['timeline'])
+            return json_response({"thumbnails": self.project['thumbnails']['timeline']})
         else:
             # set processing flag
             self.project = app.mongo.db.projects.find_one_and_update(

--- a/src/videoserver/apps/projects/routes.py
+++ b/src/videoserver/apps/projects/routes.py
@@ -543,50 +543,44 @@ class RetrieveEditDestroyProject(MethodView):
         # validate trim
         if 'trim' in document:
             if document['trim']['start'] >= document['trim']['end']:
-                raise BadRequest({"trim": [{"start": ["must be less than 'end' value"]}]})
+                raise BadRequest({"trim": ["'start' value must be less than 'end' value"]})
             elif (document['trim']['end'] - document['trim']['start'] < app.config.get('MIN_TRIM_DURATION')) \
                     or (metadata['duration'] - document['trim']['start'] < app.config.get('MIN_TRIM_DURATION')):
                 raise BadRequest({"trim": [
-                    {"start": [f"trimmed video must be at least {app.config.get('MIN_TRIM_DURATION')} seconds"]}
+                    f"Trimmed video duration must be at least {app.config.get('MIN_TRIM_DURATION')} seconds"
                 ]})
             elif document['trim']['end'] > metadata['duration']:
                 document['trim']['end'] = metadata['duration']
                 logger.info(
-                    f"Trimmed video endtime greater than video duration, update it to equal duration, "
+                    f"Trimmed video endtime is greater than video duration, update it to equal duration, "
                     f"ID: {self.project['_id']}")
             elif document['trim']['start'] == 0 and document['trim']['end'] == metadata['duration']:
-                raise BadRequest({"trim": [
-                    {"end": ["trim is duplicating an entire video"]}
-                ]})
+                raise BadRequest({"trim": ["'end' value of trim is duplicating an entire video"]})
         # validate crop
         if 'crop' in document:
             if metadata['width'] - document['crop']['x'] < app.config.get('MIN_VIDEO_WIDTH'):
-                raise BadRequest({"crop": [{"x": ["less than minimum allowed crop width"]}]})
+                raise BadRequest({"crop": ["x is less than minimum allowed crop width"]})
             elif metadata['height'] - document['crop']['y'] < app.config.get('MIN_VIDEO_HEIGHT'):
-                raise BadRequest({"crop": [{"y": ["less than minimum allowed crop height"]}]})
+                raise BadRequest({"crop": ["y is less than minimum allowed crop height"]})
             elif document['crop']['x'] + document['crop']['width'] > metadata['width']:
-                raise BadRequest({"crop": [{"width": ["crop's frame is outside a video's frame"]}]})
+                raise BadRequest({"crop": ["width of crop's frame is outside a video's frame"]})
             elif document['crop']['y'] + document['crop']['height'] > metadata['height']:
-                raise BadRequest({"crop": [{"height": ["crop's frame is outside a video's frame"]}]})
+                raise BadRequest({"crop": ["height of crop's frame is outside a video's frame"]})
         # validate scale
         if 'scale' in document:
             width = metadata['width']
             if 'crop' in document:
                 width = document['crop']['width']
             if document['scale'] == width:
-                raise BadRequest({"trim": [
-                    {"scale": ["video or crop option already has exactly the same width"]}
-                ]})
+                raise BadRequest({"trim": ["video and crop option have exactly the same width"]})
             elif not app.config.get('ALLOW_INTERPOLATION') and document['scale'] > width:
-                raise BadRequest({"trim": [
-                    {"scale": ["interpolation of pixels is not allowed"]}
-                ]})
+                raise BadRequest({"trim": ["interpolation of pixels is not allowed"]})
             elif app.config.get('ALLOW_INTERPOLATION') \
                     and document['scale'] > width \
                     and width >= app.config.get('INTERPOLATION_LIMIT'):
                 raise BadRequest({"trim": [
-                    {"scale": [f"interpolation is permitted only for videos which have width less than "
-                               f"{app.config.get('INTERPOLATION_LIMIT')}px"]}
+                    f"interpolation is permitted only for videos which have width less than "
+                    f"{app.config.get('INTERPOLATION_LIMIT')}px"
                 ]})
 
         # set processing flag
@@ -1158,13 +1152,13 @@ class RetrieveOrCreateThumbnails(MethodView):
         # validate crop param
         if crop:
             if self.project['metadata']['width'] - crop['x'] < app.config.get('MIN_VIDEO_WIDTH'):
-                raise BadRequest({"crop": [{"x": ["less than minimum allowed crop width"]}]})
+                raise BadRequest({"crop": ["x is less than minimum allowed crop width"]})
             elif self.project['metadata']['height'] - crop['y'] < app.config.get('MIN_VIDEO_HEIGHT'):
-                raise BadRequest({"crop": [{"y": ["less than minimum allowed crop height"]}]})
+                raise BadRequest({"crop": ["y is less than minimum allowed crop height"]})
             elif crop['x'] + crop['width'] > self.project['metadata']['width']:
-                raise BadRequest({"crop": [{"width": ["crop's frame is outside a video's frame"]}]})
+                raise BadRequest({"crop": ["width of crop's frame is outside a video's frame"]})
             elif crop['y'] + crop['height'] > self.project['metadata']['height']:
-                raise BadRequest({"crop": [{"height": ["crop's frame is outside a video's frame"]}]})
+                raise BadRequest({"crop": ["height of crop's frame is outside a video's frame"]})
         # validate position param
         if self.project['metadata']['duration'] < position:
             position = self.project['metadata']['duration']

--- a/src/videoserver/lib/utils.py
+++ b/src/videoserver/lib/utils.py
@@ -169,9 +169,9 @@ class VideoValidator(Validator):
         if limit and len(limit) == 2:
             wmin, wmax = limit
             if value['width'] < wmin:
-                self._error(field, "width is lesser than minimum allowed crop width")
+                self._error(field, f"width {value['width']} is less than minimum allowed crop width ({wmin})")
             if value['width'] > wmax:
-                self._error(field, "width is greater than maximum allowed crop width")
+                self._error(field, f"width {value['width']} is greater than maximum allowed crop width ({wmax})")
 
     def _validate_allow_crop_height(self, limit, field, value):
         """Test allowed crop height range
@@ -181,9 +181,9 @@ class VideoValidator(Validator):
         if limit and len(limit) == 2:
             hmin, hmax = limit
             if value['height'] < hmin:
-                self._error(field, "height is lesser than minimum allowed crop height")
+                self._error(field, f"height {value['height']} is less than minimum allowed crop height ({hmin})")
             if value['height'] > hmax:
-                self._error(field, "height is greater than maximum allowed crop height")
+                self._error(field, f"height {value['height']} is greater than maximum allowed crop height ({hmax})")
 
     def _validate_min_trim_start(self, min_trim, field, value):
         """Test minimum allowed trim start value

--- a/src/videoserver/lib/utils.py
+++ b/src/videoserver/lib/utils.py
@@ -153,24 +153,21 @@ class VideoValidator(Validator):
         try:
             x, y, width, height = [int(item) for item in value.split(',')]
             return {"x": x, "y": y, "width": width, "height": height}
-        except (TypeError, ValueError, AttributeError):
+        except ValueError:
+            return value
+        except (TypeError, AttributeError):
+            self._error('crop', 'must be of string type')
             return value
 
-    def _is_malformed_format(self, field, value):
-        if type(value) != dict:
-            # avoid duplicate message
-            if len(self._errors) == 0:
-                # using cerberus string type will always fail after coerced
-                self._error(field, 'must be of string type')
-            return True
-        return False
+    def _is_malformed_format(self, value):
+        return type(value) != dict
 
     def _validate_allow_crop_width(self, limit, field, value):
         """Test allowed crop width range
         The rule's arguments are validated against this schema:
         {'min': 'limit[0]', 'max': 'limit[1]'}
         """
-        if self._is_malformed_format(field, value):
+        if self._is_malformed_format(value):
             return
         if limit and len(limit) == 2:
             wmin, wmax = limit
@@ -185,7 +182,7 @@ class VideoValidator(Validator):
         The rule's arguments are validated against this schema:
         {'min': 'limit[0]', 'max': 'limit[1]'}
         """
-        if self._is_malformed_format(field, value):
+        if self._is_malformed_format(value):
             return
         if limit and len(limit) == 2:
             hmin, hmax = limit
@@ -199,9 +196,12 @@ class VideoValidator(Validator):
         """Convert trim string (x,y) to dict
         """
         try:
-            start, end = [float(item) for item in str(value).split(',')]
+            start, end = [float(item) for item in value.split(',')]
             return {"start": start, "end": end}
-        except (TypeError, ValueError):
+        except ValueError:
+            return value
+        except (TypeError, AttributeError):
+            self._error('trim', 'must be of string type')
             return value
 
     def _validate_min_trim_start(self, min_trim, field, value):
@@ -209,7 +209,7 @@ class VideoValidator(Validator):
         The rule's arguments are validated against this schema:
         {'min': 'min_trim'}
         """
-        if self._is_malformed_format(field, value):
+        if self._is_malformed_format(value):
             return
         if min_trim is not None and value.get('start', -1) < min_trim:
             self._error(field, "start time must be greater than %s" % min_trim)
@@ -219,7 +219,7 @@ class VideoValidator(Validator):
         The rule's arguments are validated against this schema:
         {'min': 'min_trim'}
         """
-        if self._is_malformed_format(field, value):
+        if self._is_malformed_format(value):
             return
         if min_trim is not None and value.get('end', -1) < min_trim:
             self._error(field, "end time must be greater than %s" % min_trim)

--- a/tests/api/test_retrieve_create_thumbnails.py
+++ b/tests/api/test_retrieve_create_thumbnails.py
@@ -80,7 +80,8 @@ def test_capture_timeline_thumbnails_409_resp(test_app, client, projects):
         )
 
         resp = client.get(url)
-        assert resp.status == '409 CONFLICT'
+        assert resp.status == '200 OK'
+        assert resp_data == {'processing': True, 'thumbnails': []}
 
 
 @pytest.mark.parametrize('projects', [({'file': 'sample_0.mp4', 'duplicate': False},)], indirect=True)

--- a/tests/api/test_retrieve_create_thumbnails.py
+++ b/tests/api/test_retrieve_create_thumbnails.py
@@ -159,7 +159,7 @@ def test_capture_preview_thumbnail_crop_fail(test_app, client, projects):
         resp = client.get(url)
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'crop': [{'x': ['less than minimum allowed crop width']}]}
+        assert resp_data == {'crop': ['x is less than minimum allowed crop width']}
 
         crop = "0,1000,640,480"
         url = url_for(
@@ -168,7 +168,7 @@ def test_capture_preview_thumbnail_crop_fail(test_app, client, projects):
         resp = client.get(url)
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'crop': [{'y': ['less than minimum allowed crop height']}]}
+        assert resp_data == {'crop': ['y is less than minimum allowed crop height']}
 
         crop = "0,0,10000,480"
         url = url_for(
@@ -195,7 +195,7 @@ def test_capture_preview_thumbnail_crop_fail(test_app, client, projects):
         resp = client.get(url)
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'crop': [{'width': ["crop's frame is outside a video's frame"]}]}
+        assert resp_data == {'crop': ["width of crop's frame is outside a video's frame"]}
 
         crop = "0,0,640,1480"
         url = url_for(
@@ -204,7 +204,7 @@ def test_capture_preview_thumbnail_crop_fail(test_app, client, projects):
         resp = client.get(url)
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'crop': [{'height': ["crop's frame is outside a video's frame"]}]}
+        assert resp_data == {'crop': ["height of crop's frame is outside a video's frame"]}
 
 
 @pytest.mark.parametrize('projects', [({'file': 'sample_0.mp4', 'duplicate': False},)], indirect=True)

--- a/tests/api/test_retrieve_create_thumbnails.py
+++ b/tests/api/test_retrieve_create_thumbnails.py
@@ -18,13 +18,13 @@ def test_capture_timeline_thumbnails_success(test_app, client, projects):
         resp = client.get(url)
         resp_data = json.loads(resp.data)
         assert resp.status == '202 ACCEPTED'
-        assert resp_data == {'processing': True}
+        assert resp_data == {'processing': True, 'thumbnails': []}
 
         resp = client.get(url)
         resp_data = json.loads(resp.data)
         assert resp.status == '200 OK'
-        assert len(resp_data) == amount
-        for thumbnail_data in resp_data:
+        assert len(resp_data['thumbnails']) == amount
+        for thumbnail_data in resp_data['thumbnails']:
             assert test_app.fs.get(thumbnail_data['storage_id']).__class__ is bytes
 
 
@@ -47,13 +47,13 @@ def test_capture_timeline_thumbnails_remove_old(test_app, client, projects):
         resp = client.get(url)
         resp_data = json.loads(resp.data)
         assert resp.status == '202 ACCEPTED'
-        assert resp_data == {'processing': True}
+        assert resp_data == {'processing': True, 'thumbnails': []}
 
         resp = client.get(url)
         resp_data = json.loads(resp.data)
         assert resp.status == '200 OK'
-        assert len(resp_data) == amount
-        for thumbnail_data in resp_data:
+        assert len(resp_data['thumbnails']) == amount
+        for thumbnail_data in resp_data['thumbnails']:
             assert test_app.fs.get(thumbnail_data['storage_id']).__class__ is bytes
 
 
@@ -69,7 +69,7 @@ def test_capture_timeline_thumbnails_409_resp(test_app, client, projects):
         resp = client.get(url)
         resp_data = json.loads(resp.data)
         assert resp.status == '202 ACCEPTED'
-        assert resp_data == {'processing': True}
+        assert resp_data == {'processing': True, 'thumbnails': []}
 
         # since we use CELERY_TASK_ALWAYS_EAGER, task will be executed immediately,
         # it means next request will return a finshed result,

--- a/tests/api/test_retrieve_create_thumbnails.py
+++ b/tests/api/test_retrieve_create_thumbnails.py
@@ -176,7 +176,7 @@ def test_capture_preview_thumbnail_crop_fail(test_app, client, projects):
         resp = client.get(url)
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'crop': ['width is greater than maximum allowed crop width']}
+        assert resp_data == {'crop': ['width 10000 is greater than maximum allowed crop width (3840)']}
 
         crop = "0,0,640,10000"
         url = url_for(
@@ -185,7 +185,7 @@ def test_capture_preview_thumbnail_crop_fail(test_app, client, projects):
         resp = client.get(url)
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'crop': ['height is greater than maximum allowed crop height']}
+        assert resp_data == {'crop': ['height 10000 is greater than maximum allowed crop height (2160)']}
 
         crop = "0,0,1640,480"
         url = url_for(

--- a/tests/api/test_retrieve_edit_destroy.py
+++ b/tests/api/test_retrieve_edit_destroy.py
@@ -380,7 +380,7 @@ def test_edit_project_crop_fail(test_app, client, projects):
         )
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'crop': ['width is greater than maximum allowed crop width']}
+        assert resp_data == {'crop': ['width 10000 is greater than maximum allowed crop width (3840)']}
 
         # edit request
         resp = client.put(
@@ -392,7 +392,7 @@ def test_edit_project_crop_fail(test_app, client, projects):
         )
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'crop': ['width is lesser than minimum allowed crop width']}
+        assert resp_data == {'crop': ['width 300 is less than minimum allowed crop width (320)']}
 
         # edit request
         resp = client.put(
@@ -404,7 +404,7 @@ def test_edit_project_crop_fail(test_app, client, projects):
         )
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'crop': ['height is lesser than minimum allowed crop height']}
+        assert resp_data == {'crop': ['height 100 is less than minimum allowed crop height (180)']}
 
 
 @pytest.mark.parametrize('projects', [({'file': 'sample_0.mp4', 'duplicate': True},)], indirect=True)

--- a/tests/api/test_retrieve_edit_destroy.py
+++ b/tests/api/test_retrieve_edit_destroy.py
@@ -199,7 +199,7 @@ def test_edit_project_trim_fail(test_app, client, projects):
         )
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'trim': [{'start': ["must be less than 'end' value"]}]}
+        assert resp_data == {'trim': ["'start' value must be less than 'end' value"]}
 
         # edit request
         resp = client.put(
@@ -211,7 +211,7 @@ def test_edit_project_trim_fail(test_app, client, projects):
         )
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'trim': [{'start': ['trimmed video must be at least 2 seconds']}]}
+        assert resp_data == {'trim': ['Trimmed video duration must be at least 2 seconds']}
 
         # edit request
         resp = client.put(
@@ -223,7 +223,7 @@ def test_edit_project_trim_fail(test_app, client, projects):
         )
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'trim': [{'end': ['trim is duplicating an entire video']}]}
+        assert resp_data == {'trim': ["'end' value of trim is duplicating an entire video"]}
 
         # edit request
         resp = client.put(
@@ -332,7 +332,7 @@ def test_edit_project_crop_fail(test_app, client, projects):
         )
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'crop': [{'x': ['less than minimum allowed crop width']}]}
+        assert resp_data == {'crop': ['x is less than minimum allowed crop width']}
 
         # edit request
         resp = client.put(
@@ -344,7 +344,7 @@ def test_edit_project_crop_fail(test_app, client, projects):
         )
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'crop': [{'y': ['less than minimum allowed crop height']}]}
+        assert resp_data == {'crop': ['y is less than minimum allowed crop height']}
 
         # edit request
         resp = client.put(
@@ -356,7 +356,7 @@ def test_edit_project_crop_fail(test_app, client, projects):
         )
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'crop': [{'width': ["crop's frame is outside a video's frame"]}]}
+        assert resp_data == {'crop': ["width of crop's frame is outside a video's frame"]}
 
         # edit request
         resp = client.put(
@@ -368,7 +368,7 @@ def test_edit_project_crop_fail(test_app, client, projects):
         )
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'crop': [{'height': ["crop's frame is outside a video's frame"]}]}
+        assert resp_data == {'crop': ["height of crop's frame is outside a video's frame"]}
 
         # edit request
         resp = client.put(
@@ -472,7 +472,7 @@ def test_edit_project_scale_fail(test_app, client, projects):
         )
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
-        assert resp_data == {'trim': [{'scale': ['video or crop option already has exactly the same width']}]}
+        assert resp_data == {'trim': ['video and crop option have exactly the same width']}
 
         # edit request
         resp = client.put(
@@ -485,7 +485,7 @@ def test_edit_project_scale_fail(test_app, client, projects):
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
         assert resp_data == {
-            'trim': [{'scale': ['interpolation is permitted only for videos which have width less than 1280px']}]
+            'trim': ['interpolation is permitted only for videos which have width less than 1280px']
         }
 
         # edit request
@@ -500,7 +500,7 @@ def test_edit_project_scale_fail(test_app, client, projects):
         resp_data = json.loads(resp.data)
         assert resp.status == '400 BAD REQUEST'
         assert resp_data == {
-            'trim': [{'scale': ['interpolation of pixels is not allowed']}]
+            'trim': ['interpolation of pixels is not allowed']
         }
 
 

--- a/tests/api/test_retrieve_edit_destroy.py
+++ b/tests/api/test_retrieve_edit_destroy.py
@@ -189,6 +189,30 @@ def test_edit_project_trim_fail(test_app, client, projects):
     with test_app.test_request_context():
         url = url_for('projects.retrieve_edit_destroy_project', project_id=project['_id'])
 
+        # incorrect type
+        resp = client.put(
+            url,
+            data=json.dumps({
+                "trim": 123
+            }),
+            content_type='application/json'
+        )
+        resp_data = json.loads(resp.data)
+        assert resp.status == '400 BAD REQUEST'
+        assert resp_data == {'trim': ["must be of string type"]}
+
+        # malformed format
+        resp = client.put(
+            url,
+            data=json.dumps({
+                "trim": "x,y"
+            }),
+            content_type='application/json'
+        )
+        resp_data = json.loads(resp.data)
+        assert resp.status == '400 BAD REQUEST'
+        assert resp_data == {'trim': ["value does not match regex '^\\d+\\.?\\d*,\\d+\\.?\\d*$'"]}
+
         # edit request
         resp = client.put(
             url,
@@ -321,6 +345,30 @@ def test_edit_project_crop_fail(test_app, client, projects):
 
     with test_app.test_request_context():
         url = url_for('projects.retrieve_edit_destroy_project', project_id=project['_id'])
+
+        # incorrect type
+        resp = client.put(
+            url,
+            data=json.dumps({
+                "crop": 1
+            }),
+            content_type='application/json'
+        )
+        resp_data = json.loads(resp.data)
+        assert resp.status == '400 BAD REQUEST'
+        assert resp_data == {'crop': ["must be of string type"]}
+
+        # malformed format
+        resp = client.put(
+            url,
+            data=json.dumps({
+                "crop": "x,y,w,h"
+            }),
+            content_type='application/json'
+        )
+        resp_data = json.loads(resp.data)
+        assert resp.status == '400 BAD REQUEST'
+        assert resp_data == {'crop': ["value does not match regex '^\\d+,\\d+,\\d+,\\d+$'"]}
 
         # edit request
         resp = client.put(


### PR DESCRIPTION
- Update error response for edit video and thumbnails for consistency
- Add information for crop error response, current response `width is less than minimum allowed crop width` is not useful, user can't know what `minium allowed crop` value is when we show the error on the client.
- Add `thumbnails` for get `timeline`, if task timeline is accepted, return empty
- Fix #20 