### PR TITLE
Add range end headers support and fix ffmpeg error

### DIFF
--- a/src/videoserver/apps/projects/routes.py
+++ b/src/videoserver/apps/projects/routes.py
@@ -325,7 +325,7 @@ class ListUploadProject(MethodView):
                 '_meta': {
                     'page': page,
                     'max_results': app.config.get('ITEMS_PER_PAGE'),
-                    'total': app.mongo.db.projects.count()
+                    'total': app.mongo.db.projects.estimated_document_count()
                 }
             }
         )

--- a/src/videoserver/apps/projects/routes.py
+++ b/src/videoserver/apps/projects/routes.py
@@ -524,7 +524,7 @@ class RetrieveEditDestroyProject(MethodView):
             raise Conflict({"processing": ["Task edit video is still processing"]})
 
         if self.project['version'] == 1:
-            raise BadRequest({"project_id": [f"Video with version 1 is not editable, use duplicated project instead."]})
+            raise BadRequest({"project_id": ["Video with version 1 is not editable, use duplicated project instead."]})
 
         request_json = request.get_json()
         document = validate_document(

--- a/src/videoserver/apps/projects/routes.py
+++ b/src/videoserver/apps/projects/routes.py
@@ -1230,10 +1230,12 @@ class GetRawVideo(MethodView):
         video_range = request.headers.environ.get('HTTP_RANGE')
         length = self.project['metadata'].get('size')
         if video_range:
+            # http range bytes=0-
             _range = re.split('[= | -]', video_range)
             start = int(_range[1])
             # TODO doublecheck streaming range
             end = length - 1
+            # handle end range part in case of bytes=100-200
             if len(_range) == 3 and _range[2]:
                 end = int(_range[2])
             chunksize = end - start + 1

--- a/src/videoserver/apps/projects/routes.py
+++ b/src/videoserver/apps/projects/routes.py
@@ -1230,9 +1230,12 @@ class GetRawVideo(MethodView):
         video_range = request.headers.environ.get('HTTP_RANGE')
         length = self.project['metadata'].get('size')
         if video_range:
-            start = int(re.split('[= | -]', video_range)[1])
+            _range = re.split('[= | -]', video_range)
+            start = int(_range[1])
             # TODO doublecheck streaming range
             end = length - 1
+            if len(_range) == 3 and _range[2]:
+                end = int(_range[2])
             chunksize = end - start + 1
 
             return storage2response(

--- a/src/videoserver/lib/video_editor/ffmpeg.py
+++ b/src/videoserver/lib/video_editor/ffmpeg.py
@@ -83,6 +83,9 @@ class FFMPEGVideoEditor(VideoEditorInterface):
             # https://trac.ffmpeg.org/wiki/Scaling
             if scale:
                 filter_string += ',' if filter_string != '' else ''
+                # avoid width not divisible by 2
+                if scale % 2 == 1:
+                    scale -= 1
                 filter_string += f"scale={scale}:-2"
             # rotate
             # https://ffmpeg.org/ffmpeg-all.html#transpose

--- a/src/videoserver/lib/video_editor/ffmpeg.py
+++ b/src/videoserver/lib/video_editor/ffmpeg.py
@@ -212,9 +212,9 @@ class FFMPEGVideoEditor(VideoEditorInterface):
         try:
             # time period between two frames
             if thumbnails_amount == 1:
-                frame_per_second = (duration - 1)
+                frame_per_second = (duration - 0.05)
             else:
-                frame_per_second = (duration - 1) / (thumbnails_amount - 1)
+                frame_per_second = (duration - 0.05) / (thumbnails_amount - 1)
 
             # capture list frame via script capture_list_frames.sh
             path_script = os.path.dirname(__file__) + '/script/capture_list_frames.sh'

--- a/src/videoserver/lib/video_editor/ffmpeg.py
+++ b/src/videoserver/lib/video_editor/ffmpeg.py
@@ -163,7 +163,7 @@ class FFMPEGVideoEditor(VideoEditorInterface):
                 vfilter = f'-vf crop={crop["width"]}:{crop["height"]}:{crop["x"]}:{crop["y"]}'
             if rotate:
                 vfilter += ',' if vfilter else '-vf '
-                transpose = f'transpose=1' if rotate > 0 else f'transpose=2'
+                transpose = 'transpose=1' if rotate > 0 else 'transpose=2'
                 vfilter += ','.join([transpose] * abs(rotate // 90))
 
             try:

--- a/tests/api/test_get_raw_thumbnails.py
+++ b/tests/api/test_get_raw_thumbnails.py
@@ -47,7 +47,7 @@ def test_get_raw_preview_thumbnail_success(test_app, client, projects):
         # capture preview thumbnail
         url = url_for(
             'projects.retrieve_or_create_thumbnails', project_id=project['_id']
-        ) + f'?type=preview&position=5'
+        ) + '?type=preview&position=5'
         client.get(url)
         # get raw preview thumbnail
         url = url_for('projects.get_raw_preview_thumbnail', project_id=project['_id'])


### PR DESCRIPTION
- Add support end part in `range` HEADER (for safari browser)
- Fix error not divisible by 2
- Reduce end frame subtraction (use for avoid black screen on video end frame) from `1s` to `0.05s` so that the client could render thumbnail at the end for short video (e.g. 5s)
- Replace `count` with `estimated_document_count` (Pymongo warning)